### PR TITLE
chore: use `@babel/register` instead of `esm`

### DIFF
--- a/.esmrc.json
+++ b/.esmrc.json
@@ -1,5 +1,0 @@
-{
-    "cache": true,
-    "debug": true,
-    "sourceMap": true
-}

--- a/.nycrc.yml
+++ b/.nycrc.yml
@@ -4,4 +4,4 @@ reporter:
     - lcov
     - text-summary
 require:
-    - esbuild-register
+    - "@babel/register"

--- a/.nycrc.yml
+++ b/.nycrc.yml
@@ -4,4 +4,4 @@ reporter:
     - lcov
     - text-summary
 require:
-    - esm
+    - esbuild-register

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+/* eslint-env node */
+"use strict"
+
+module.exports = {
+    plugins: ["@babel/plugin-transform-modules-commonjs"],
+}

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
         "eslint-visitor-keys": "^3.3.0"
     },
     "devDependencies": {
+        "@babel/core": "^7.20.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.19.6",
+        "@babel/register": "^7.18.9",
         "@eslint-community/eslint-plugin-mysticatea": "^15.2.0",
         "dot-prop": "^6.0.1",
-        "esbuild": "^0.15.15",
-        "esbuild-register": "^3.4.1",
         "eslint": "^8.28.0",
         "espree": "github:eslint/espree#1c744b3a602b783926344811a9459b92afe57444",
         "mocha": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "devDependencies": {
         "@eslint-community/eslint-plugin-mysticatea": "^15.2.0",
         "dot-prop": "^6.0.1",
+        "esbuild": "^0.15.15",
         "esbuild-register": "^3.4.1",
         "eslint": "^8.28.0",
         "espree": "github:eslint/espree#1c744b3a602b783926344811a9459b92afe57444",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "devDependencies": {
         "@eslint-community/eslint-plugin-mysticatea": "^15.2.0",
         "dot-prop": "^6.0.1",
+        "esbuild-register": "^3.4.1",
         "eslint": "^8.28.0",
-        "esm": "^3.2.25",
         "espree": "github:eslint/espree#1c744b3a602b783926344811a9459b92afe57444",
         "mocha": "^8.4.0",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
This PR is a PR to the eslint-8 branch.
This PR uses ~~`esbuild-register`~~ `@babel/register` instead of the `esm` package. The `esm` package doesn't seem to work when mixed with real ESM modules.

https://github.com/mochajs/mocha/issues/4671