### PR TITLE
chore: remove `espree` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
         "@eslint-community/eslint-plugin-mysticatea": "^15.2.0",
         "dot-prop": "^6.0.1",
         "eslint": "^8.28.0",
-        "espree": "github:eslint/espree#1c744b3a602b783926344811a9459b92afe57444",
         "mocha": "^8.4.0",
         "npm-run-all": "^4.1.5",
         "nyc": "^15.1.0",


### PR DESCRIPTION
Re-submission of #6 

> Looking at the codebase, we're never using `espree` anywhere.
> Looking at #2, tests are still passing when using the `espree` dependency of ESLint.
> 
> So I think it's safe to remove `espree` from our `devDependencies`