### PR TITLE
chore: fix docs workflow

### DIFF
--- a/.github/workflows/GHPages.yml
+++ b/.github/workflows/GHPages.yml
@@ -29,7 +29,7 @@ jobs:
               with:
                   node-version: 18
             - name: Install Packages
-              run: npm ci
+              run: npm install
             - name: Build docs
               run: |+
                   export NODE_OPTIONS=--openssl-legacy-provider


### PR DESCRIPTION
I was using 'npm ci' by mistake. This PR will be fixed to `npm install`.