### PR TITLE
fix: `getStaticValue` for `Math.random()`

### DIFF
--- a/src/get-static-value.mjs
+++ b/src/get-static-value.mjs
@@ -79,6 +79,7 @@ const callAllowed = new Set(
         isNaN,
         isPrototypeOf,
         ...Object.getOwnPropertyNames(Math)
+            .filter((k) => k !== "random")
             .map((k) => Math[k])
             .filter((f) => typeof f === "function"),
         Number,

--- a/test/get-static-value.mjs
+++ b/test/get-static-value.mjs
@@ -43,6 +43,8 @@ describe("The 'getStaticValue' function", () => {
         { code: "foo(7)", expected: null },
         { code: "obj.foo(7)", expected: null },
         { code: "Math.round(a)", expected: null },
+        { code: "Math.random()", expected: null },
+        { code: "Math['random']()", expected: null },
         { code: "true ? 1 : c", expected: { value: 1 } },
         { code: "false ? b : 2", expected: { value: 2 } },
         { code: "a ? 1 : 2", expected: null },


### PR DESCRIPTION
This is a port of https://github.com/mysticatea/eslint-utils/pull/28 to fix https://github.com/mysticatea/eslint-utils/issues/27. As explained in the issue, `Math.random()` is naturally non-deterministic, which isn't ideal for static evaluation :)
