### PR TITLE
chore: remove `styfle/cancel-workflow-action` usage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,14 +13,15 @@ on:
     schedule:
         - cron: 0 0 * * 0
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     lint:
         name: ⬣ Lint
         runs-on: ubuntu-latest
         steps:
-            - name: 🛑 Cancel Previous Runs
-              uses: styfle/cancel-workflow-action@0.11.0
-
             - name: ⬇️ Checkout repo
               uses: actions/checkout@v3
 
@@ -68,9 +69,6 @@ jobs:
                       os: ubuntu-latest
         runs-on: ${{ matrix.os }}
         steps:
-            - name: 🛑 Cancel Previous Runs
-              uses: styfle/cancel-workflow-action@0.11.0
-
             - name: ⬇️ Checkout repo
               uses: actions/checkout@v3
 
@@ -102,9 +100,6 @@ jobs:
             contains('refs/heads/main,refs/heads/next,refs/heads/beta,refs/heads/alpha',
             github.ref) && github.event_name == 'push'
         steps:
-            - name: 🛑 Cancel Previous Runs
-              uses: styfle/cancel-workflow-action@0.11.0
-
             - name: ⬇️ Checkout repo
               uses: actions/checkout@v3
 


### PR DESCRIPTION
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
- https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency
- > The fully-formed ref of the branch or tag that triggered the workflow run. For workflows triggered by `push`, this is the branch or tag ref that was pushed. For workflows triggered by `pull_request`, this is the pull request merge branch. For workflows triggered by `release`, this is the release tag created. For other triggers, this is the branch or tag ref that triggered the workflow run. This is only set if a branch or tag is available for the event type. The ref given is fully-formed, meaning that for branches the format is `refs/heads/<branch_name>`, for pull requests it is `refs/pull/<pr_number>/merge`, and for tags it is `refs/tags/<tag_name>`. For example, `refs/heads/feature-branch-1`.
  
  https://docs.github.com/en/actions/learn-github-actions/contexts#github-context