### PR TITLE
feat: drop Node 12, 14 & 16 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         strategy:
             matrix:
                 eslint: [8]
-                node: [12.22.0, 12, 14.17.0, 14, 16, 18, 20, 22]
+                node: [18.18.0, 18, 20.9.0, 20, 22]
                 os: [ubuntu-latest]
                 include:
                     # On other platforms

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
     },
     "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
     },
     "funding": "https://opencollective.com/eslint"
 }


### PR DESCRIPTION
BREAKING CHANGE: Requires Node@^18.18.0 || ^20.9.0 || >=21.1.0

---

Supersedes #234

Closes #232