### PR TITLE
chore: use Node 22 for main tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             - name: ⎔ Setup Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
 
             - name: 📥 Install dependencies
               run: npm install
@@ -109,7 +109,7 @@ jobs:
             - name: ⎔ Setup node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
 
             - name: 📥 Install dependencies
               run: npm install


### PR DESCRIPTION
Node 20 is in maintenance mode as of 2024-10-22 and Node 22 is active LTS as of 2024-10-29

https://github.com/nodejs/release#release-schedule