### PR TITLE
feat!: update package exports and rollup config to drop CommonJS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "sideEffects": false,
     "exports": {
         ".": {
-            "import": "./index.mjs",
-            "require": "./index.js"
+            "types": "./index.d.mts",
+            "import": "./index.mjs"
         },
         "./package.json": "./package.json"
     },
-    "main": "index",
+    "main": "index.mjs",
     "module": "index.mjs",
     "files": [
         "index.*"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -50,4 +50,4 @@ for (const file of fs.readdirSync(path.resolve("dist"))) {
     }
 }
 
-export default [...config(".js"), ...config(".mjs")]
+export default [...config(".mjs")]


### PR DESCRIPTION
BREAKING CHANGE: drop cjs

This pull request makes changes to the package export and build configurations to improve module resolution and output consistency. The most important changes are:

**Package export and entry points:**

* Updated the `exports` field in `package.json` to explicitly specify the `types` entry and remove the `require` field, ensuring only ESM (`.mjs`) is used for imports and as the main entry point. (`package.json`)
* Changed the `main` field in `package.json` to point to `index.mjs` instead of the ambiguous `index`, clarifying the main module format. (`package.json`)

**Build configuration:**

* Modified the build output in `rollup.config.js` to only generate `.mjs` files, removing `.js` builds for a more consistent ESM-only distribution. (`rollup.config.js`)